### PR TITLE
Rename "new contributor" label to "good first issue"

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,7 +23,7 @@
     "name": "help wanted",
     "color": "d4c5f9"
 }, {
-    "name": "new contributor",
+    "name": "good first issue",
     "color": "d4c5f9"
 }, {
     "name": "non-issue",


### PR DESCRIPTION
Per https://github.com/hapijs/contrib/pull/123 we're going to rename the `new contributor` label to the more standard `good first issue` label.

Originally I planned to include some code here so that maintainers could migrate their repos' labels, but I'm actually going to just perform the update to all hapijs repos in one fell swoop, so this little configuration change should be sufficient going forward 👍 